### PR TITLE
fix: Change OCR to send back success, but with a quality warning

### DIFF
--- a/src/main/java/uk/gov/fco/documentupload/api/FileController.java
+++ b/src/main/java/uk/gov/fco/documentupload/api/FileController.java
@@ -137,14 +137,14 @@ public class FileController {
                         for (FileUpload upload : uploads) {
                             if (!ocrService.passesQualityCheck(upload)) {
                                 passedQualityCheck = false;
-                                break;
                             }
                         }
                         if (!passedQualityCheck) {
-                            log.info("Quality check failed for file");
-                            output.setResult(ResponseEntity
-                                    .status(HttpStatus.UNPROCESSABLE_ENTITY)
-                                    .body("qualityError"));
+                            log.info("Quality check failed for file. Uploading file and returning warning");
+                            String id = storageClient.store(merger.merge(uploads));
+                            output.setResult(
+                                    ResponseEntity
+                                            .created(builder.path("/files/{id}").build(id)).body("qualityWarning"));
                         } else {
                             log.info("File is good quality, uploading file");
                             String id = storageClient.store(merger.merge(uploads));

--- a/src/main/java/uk/gov/fco/documentupload/service/storage/S3StorageClient.java
+++ b/src/main/java/uk/gov/fco/documentupload/service/storage/S3StorageClient.java
@@ -1,6 +1,5 @@
 package uk.gov.fco.documentupload.service.storage;
 
-import com.amazonaws.auth.EnvironmentVariableCredentialsProvider;
 import com.amazonaws.services.s3.AmazonS3;
 import com.amazonaws.services.s3.AmazonS3ClientBuilder;
 import com.amazonaws.services.s3.model.ObjectMetadata;
@@ -22,7 +21,7 @@ public class S3StorageClient extends StorageClient {
 
     public S3StorageClient(@Value("${storage.s3.bucket}") @NonNull String bucket) {
         this.bucket = bucket;
-        amazonS3 = AmazonS3ClientBuilder.standard().withRegion("eu-west-2").withCredentials(new EnvironmentVariableCredentialsProvider()).build();
+        amazonS3 = AmazonS3ClientBuilder.defaultClient();
     }
 
     @Override

--- a/src/main/java/uk/gov/fco/documentupload/service/storage/S3StorageClient.java
+++ b/src/main/java/uk/gov/fco/documentupload/service/storage/S3StorageClient.java
@@ -22,7 +22,7 @@ public class S3StorageClient extends StorageClient {
 
     public S3StorageClient(@Value("${storage.s3.bucket}") @NonNull String bucket) {
         this.bucket = bucket;
-        amazonS3 = AmazonS3ClientBuilder.defaultClient();
+        amazonS3 = AmazonS3ClientBuilder.standard().withRegion("eu-west-2").withCredentials(new EnvironmentVariableCredentialsProvider()).build();
     }
 
     @Override


### PR DESCRIPTION
Previously OCR would return a 422, which resulted in the user getting an error in the form runner. Users didn't respond well to the hard stop, so instead we have opted for a playback page which suggests the user reupload their image, but doesn't stop them from continuing.

To facilitate this, the document upload now returns a success, and the file upload location, but returns the success with an image quality warning if the quality threshold wasn't met.